### PR TITLE
added Requested Other Help to Application View and Vetting Worksheet …

### DIFF
--- a/public/javascripts/xedit.js
+++ b/public/javascripts/xedit.js
@@ -314,6 +314,7 @@ $(document).ready(function() {
     $('#l_client_contrib').editable();
     $('#l_associate_contrib').editable();
     $('#fbo_name').editable();
+    $('#requested_other_help_description').editable();
 
     $('#advocate_name').editable();
     $('#advocate_org_name').editable();

--- a/views/b3-view.hbs
+++ b/views/b3-view.hbs
@@ -372,7 +372,10 @@
                 <tr>
                     <td></td>
                     <td>Associate Labor/Materials Contribution</td>
-                    <td><a href="#" id="l_associate_contrib" data-type="text" data-pk="1" data-url="/edit/{{doc._id}}" data-name="property.associates_can_contribute.description" data-title="Enter Contribution Description">{{doc.property.associates_can_contribute.description}}</a></td>
+                    <td><a href="#" id="l_associate_contrib" data-type="text" data-pk="1" 
+                            data-url="/edit/{{doc._id}}"
+                            data-name="property.associates_can_contribute.description"
+                            data-title="Enter Contribution Description">{{doc.property.associates_can_contribute.description}}</a></td>
                 </tr>
                 <tr>
                     <td><a id="recruitment.fbo_help"class="highlight">{{highlight.recruitment.fbo_help}}</a></td>
@@ -391,6 +394,16 @@
                     <td>Requested Other Help</td>
                     <td><a href="#" id="request_help" data-type="select" data-pk="1" data-url="/edit/{{doc._id}}" data-name="finance.requested_other_help.value" data-title="Client Requested Other Help?"></a></td>
                 </tr>
+                <!-- THIS IS THE CHANGED PORTION - please remove this comment when it works -->
+                <tr>
+                    <td></td>
+                    <td>Organization Names and Help Requested</td>
+                    <td><a href="#" id="requested_other_help_description" 
+                           data-type="text" data-pk="1" data-url="/edit/{{doc._id}}"
+                           data-name="finance.requested_other_help.description"
+                           data-title="Enter Organization Names and Help Requested">{{doc.finance.requested_other_help.description}}</a></td>
+                </tr>
+                <!-- THIS IS THE END OF THE CHANGED PORTION - please remove this comment when it works -->
                 </tbody>
             </table>
 

--- a/views/b3-view.hbs
+++ b/views/b3-view.hbs
@@ -394,7 +394,6 @@
                     <td>Requested Other Help</td>
                     <td><a href="#" id="request_help" data-type="select" data-pk="1" data-url="/edit/{{doc._id}}" data-name="finance.requested_other_help.value" data-title="Client Requested Other Help?"></a></td>
                 </tr>
-                <!-- THIS IS THE CHANGED PORTION - please remove this comment when it works -->
                 <tr>
                     <td></td>
                     <td>Organization Names and Help Requested</td>
@@ -403,7 +402,6 @@
                            data-name="finance.requested_other_help.description"
                            data-title="Enter Organization Names and Help Requested">{{doc.finance.requested_other_help.description}}</a></td>
                 </tr>
-                <!-- THIS IS THE END OF THE CHANGED PORTION - please remove this comment when it works -->
                 </tbody>
             </table>
 

--- a/views/b3-worksheet-view.hbs
+++ b/views/b3-worksheet-view.hbs
@@ -629,6 +629,14 @@
 				<td>Requested Other Help</td>
 				<td><a href="#" id="request_help" data-type="select" data-pk="1" data-url="/edit/{{doc._id}}" data-name="finance.requested_other_help.value" data-title="Client Requested Other Help?"></a></td>
 			</tr>
+			<tr>
+				<td></td>
+				<td>Organization Names and Help Requested</td>
+				<td><a href="#" id="requested_other_help_description" data-type="text" data-pk="1" data-url="/edit/{{doc._id}}"
+						data-name="finance.requested_other_help.description"
+						data-title="Enter Organization Names and Help Requested">{{doc.finance.requested_other_help.description}}</a>
+				</td>
+			</tr>
 		{{/if}}
 
 	{{#if doc.advocate.is_advocate}}


### PR DESCRIPTION
Developer: Mike Haines

#95 Requested Other Help
Highlights:

- The requested other help is now visible on both application view and vetting worksheet.
- They are editable inline on both pages
- Tested both in local and they both appear and are editable and changes reflect in database and persist on the screen.

Once tested in the develop instance, this should fix issue #95 
Close #95 if it works, message me if it doesn't