### PR TITLE
159 - Add Vetting Google Drive Link workflow

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -1125,7 +1125,10 @@ getDocumentPlanning: function (req, res, next) {
                 updates = {"project.project_end":req.body.value };
         } else if (req.body.name == "drive_url") {
                 updates = {"drive.drive_url":req.body.value };
+        } else if (req.body.name == "vetting_drive_url") {
+                updates = { "drive.vetting_drive_url": req.body.value };
         }   
+
 
         // else {
         

--- a/models/documentPackage.js
+++ b/models/documentPackage.js
@@ -208,7 +208,8 @@ var DocumentPackageSchema = new Schema({
     // Store external links to documents (and client photos in the future).
     drive:      {
         photos: String,
-        drive_url: String
+        drive_url: String,
+        vetting_drive_url: String
     }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2754,8 +2754,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/views/b3-view.hbs
+++ b/views/b3-view.hbs
@@ -4,14 +4,14 @@
 	}
 	.btnEditDrive {
 		font-size: 14px;
-		margin-left: 20px;
+		margin-left: 5px;
 		margin-bottom: 5px;
 		margin-top: -3px;
-		}
+	}
 	.shallow {
 		font-size: 14px;
 		margin-left: 20px;
-		}
+	}
 	.no-bottom-margin {
 		margin-bottom: 0px;
 	}
@@ -23,9 +23,9 @@
         padding-left: 10px;
 	}
 	.drive-link {
-		padding-top: 0px;
+		padding-top: 5px;
         margin-top: 0px;
-        font-size: 1.8em;
+        font-size: 1.5em;
         font-weight: bold;
 	}
     .drive-input-link {
@@ -49,7 +49,7 @@
     <div class="col-sm-6 drive-button-padding">
         <!-- HBS - IF NO DRIVE LINK  - then show this. -->
         <span id="noDrive" style="display: inline-flex;">
-            <h4 class="drive-header">Drive URL:&nbsp;&nbsp;</h4>
+            <h4 class="drive-header">Project Drive URL:&nbsp;&nbsp;</h4>
             <a href="#" onclick="showDriveDone()" id="drive_url" data-type="text" data-pk="{{_id}}"
                 data-url="/edit/project/{{doc._id}}" data-name="drive_url" data-title="Drive Link" data-onblur="submit"
                 class="drive-input-link">{{doc.drive.drive_url}}</a>&nbsp;&nbsp;
@@ -61,10 +61,34 @@
 
         <span id="yesDrive" style="display: inline-flex;">
             <a id="driveHref" target="_blank" href="{{doc.drive.drive_url}}">
-                <h4 class="no-bottom-margin drive-link">Google Drive</h4>
+                <h4 class="no-bottom-margin drive-link">Google Drive - Project</h4>
             </a>
             &nbsp;&nbsp;&nbsp;&nbsp;
             <button class="btn btnEditDrive" onclick="editDriveURL()">Edit</button>
+        </span>
+    </div>
+
+    <div class="col-sm-6 drive-button-padding">
+        <!-- HBS - IF NO VETTING DRIVE LINK  - then show this. -->
+        <span id="vettingNoDrive" style="display: inline-flex;">
+            <h4 class="drive-header">Vetting Drive URL:&nbsp;&nbsp;</h4>
+            <a href="#" onclick="showVettingDriveDone()" id="vetting_drive_url"
+                data-type="text" data-pk="{{_id}}"
+                data-url="/edit/project/{{doc._id}}" data-name="vetting_drive_url" 
+                data-title="Vetting Drive Link" data-onblur="submit"
+                class="drive-input-link">{{doc.drive.vetting_drive_url}}</a>&nbsp;&nbsp;
+            <button class="btn btn-success shallow" id="vettingDriveDoneBtn" style="display: none;"
+                onclick="window.location.reload(true)">Collapse</button>
+        </span>
+    
+        <!-- HBS - IF VETTING LINK EXISTS - then show this. -->
+    
+        <span id="vettingYesDrive" style="display: inline-flex;">
+            <a id="vettingDriveHref" target="_blank" href="{{doc.drive.vetting_drive_url}}">
+                <h4 class="no-bottom-margin drive-link">Google Drive - Vetting Only</h4>
+            </a>
+            &nbsp;&nbsp;&nbsp;&nbsp;
+            <button class="btn btnEditDrive" onclick="editVettingDriveURL()">Edit</button>
         </span>
     </div>
 </div>
@@ -720,11 +744,49 @@
 
         $('[id="notes.vet_summary"]').editable();
         $('#drive_url').editable();
+        $('#vetting_drive_url').editable();
         yesDriveLoaded();
+        vettingYesDriveLoaded();
     });
 
     /**
-     * These three functions work together to display the Google Drive Button
+         * These three functions work together to display the VETTING Google Drive Button
+        **/
+        function editVettingDriveURL() {
+            //Toggle = show edit span, and hide current span
+            document.getElementById("vettingYesDrive").style.display = "none";
+            document.getElementById("vettingNoDrive").style.display = "inline-flex";
+            document.getElementById("vettingDriveDoneBtn").style.display = "inline-flex";
+        }
+
+        function showVettingDriveDone() {
+            document.getElementById("vettingDriveDoneBtn").style.display = "inline-flex";
+        }
+
+        function vettingYesDriveLoaded() {
+            var vettingWebUrl = "{{{escape doc.drive.vetting_drive_url}}}";
+            console.log('In vettingYesDriveLoaded and vettingWebUrl = ', vettingWebUrl);
+
+            if (document.getElementById("vettingDriveHref").href == "" || 
+                document.getElementById("vettingDriveHref").href == window.location || 
+                document.getElementById("vettingDriveHref").href + "#" == window.location) {
+                    document.getElementById("vettingYesDrive").style.display = "none";
+                    document.getElementById("vettingNoDrive").style.display = "inline-flex";
+            } else {
+                if (document.getElementById("vettingDriveHref") && 
+                    document.getElementById("vettingDriveHref").href) {
+                    var vettingWebUrl = "{{{escape doc.drive.vetting_drive_url}}}";
+                    if (!vettingWebUrl.startsWith('http')) {
+                        document.getElementById("vettingDriveHref").href = 'http://' + vettingWebUrl;
+                    }
+                }
+                document.getElementById("vettingYesDrive").style.display = "inline-flex";
+                document.getElementById("vettingNoDrive").style.display = "none";
+            }
+        }
+
+    /**
+     * These three functions work together to display the PROJECT Google Drive Button
     **/
     function editDriveURL() {
         //Toggle = show edit span, and hide current span

--- a/views/b3-worksheet-view.hbs
+++ b/views/b3-worksheet-view.hbs
@@ -7,10 +7,10 @@
 
 	.btnEditDrive {
 		font-size: 14px;
-		margin-left: 20px;
+		margin-left: 5px;
 		margin-bottom: 5px;
 		margin-top: -3px;
-		}
+	}
 	.shallow {
 		font-size: 14px;
 		margin-left: 20px;
@@ -25,9 +25,9 @@
 		padding-top: 15px;
 	}
 	.drive-link {
-		padding-top: 0px;
+		padding-top: 5px;
         margin-top: 0px;
-        font-size: 1.8em;
+        font-size: 1.5em;
         font-weight: bold;
 	}
     .drive-input-link {
@@ -98,6 +98,27 @@
 			</a>
 			&nbsp;&nbsp;&nbsp;&nbsp;
 			<button class="btn btnEditDrive" onclick="editDriveURL()">Edit</button>
+		</span>
+	</div>
+	<div class="col-sm-6 drive-button-padding">
+		<!-- HBS - IF NO VETTING DRIVE LINK  - then show this. -->
+		<span id="vettingNoDrive" style="display: inline-flex;">
+			<h4 class="drive-header">Vetting Drive URL:&nbsp;&nbsp;</h4>
+			<a href="#" onclick="showVettingDriveDone()" id="vetting_drive_url" data-type="text" data-pk="{{_id}}"
+				data-url="/edit/project/{{doc._id}}" data-name="vetting_drive_url" data-title="Vetting Drive Link"
+				data-onblur="submit" class="drive-input-link">{{doc.drive.vetting_drive_url}}</a>&nbsp;&nbsp;
+			<button class="btn btn-success shallow" id="vettingDriveDoneBtn" style="display: none;"
+				onclick="window.location.reload(true)">Collapse</button>
+		</span>
+	
+		<!-- HBS - IF VETTING LINK EXISTS - then show this. -->
+	
+		<span id="vettingYesDrive" style="display: inline-flex;">
+			<a id="vettingDriveHref" target="_blank" href="{{doc.drive.vetting_drive_url}}">
+				<h4 class="no-bottom-margin drive-link">Google Drive - Vetting Only</h4>
+			</a>
+			&nbsp;&nbsp;&nbsp;&nbsp;
+			<button class="btn btnEditDrive" onclick="editVettingDriveURL()">Edit</button>
 		</span>
 	</div>
 </div>
@@ -1100,9 +1121,11 @@ $(function(){
                     ]
         });
 		$('#drive_url').editable();
+		$('#vetting_drive_url').editable();
 
 		//call Google Drive Button function
 		yesDriveLoaded();
+		vettingYesDriveLoaded();
 
         /**
          * iterate through all dynamic array fields to make them editable
@@ -1216,7 +1239,43 @@ $(function(){
 		});
 
 		/**
-		 * These three functions work together to display the Google Drive Button
+			* These three functions work together to display the VETTING Google Drive Button
+		**/
+		function editVettingDriveURL() {
+			//Toggle = show edit span, and hide current span
+			document.getElementById("vettingYesDrive").style.display = "none";
+			document.getElementById("vettingNoDrive").style.display = "inline-flex";
+			document.getElementById("vettingDriveDoneBtn").style.display = "inline-flex";
+		}
+
+		function showVettingDriveDone() {
+			document.getElementById("vettingDriveDoneBtn").style.display = "inline-flex";
+		}
+
+		function vettingYesDriveLoaded() {
+			var vettingWebUrl = "{{{escape doc.drive.vetting_drive_url}}}";
+			console.log('In vettingYesDriveLoaded and vettingWebUrl = ', vettingWebUrl);
+
+			if (document.getElementById("vettingDriveHref").href == "" ||
+				document.getElementById("vettingDriveHref").href == window.location ||
+				document.getElementById("vettingDriveHref").href + "#" == window.location) {
+				document.getElementById("vettingYesDrive").style.display = "none";
+				document.getElementById("vettingNoDrive").style.display = "inline-flex";
+			} else {
+				if (document.getElementById("vettingDriveHref") &&
+					document.getElementById("vettingDriveHref").href) {
+					var vettingWebUrl = "{{{escape doc.drive.vetting_drive_url}}}";
+					if (!vettingWebUrl.startsWith('http')) {
+						document.getElementById("vettingDriveHref").href = 'http://' + vettingWebUrl;
+					}
+				}
+				document.getElementById("vettingYesDrive").style.display = "inline-flex";
+				document.getElementById("vettingNoDrive").style.display = "none";
+			}
+		}
+
+		/**
+			* These three functions work together to display the PROJECT Google Drive Button
 		**/
 		function editDriveURL() {
 			//Toggle = show edit span, and hide current span


### PR DESCRIPTION
Developer: @ironmikesh (Mike Haines)
Testing assignment: @dandahle (Dan Dahle)

Highlights:
- Added vetting google drive data point in database
- Added Google Drive Link saving and using functionality in Vetting Application View
- Added the same functionality in Vetting Worksheet View

Notes:
- npm install is REQUIRED for this change to work.
- This change will not affect old data.
- At the same time, users SHOULD be able to add a link to previously created applications.
- This link is only editable/usable in the vetting area - app view and VW, so permissions are handled through the views.  The google drive FOLDER may need additional tweaks for authorized viewers.
- See Description for more acceptance criteria.