### PR TITLE
Fix date in project controller

### DIFF
--- a/app_project/controller/app_project/project_controller.js
+++ b/app_project/controller/app_project/project_controller.js
@@ -187,7 +187,7 @@ async function edit_project(req, res) {
     || req.body.property == "project_end_date") {
     var d = new Date(
       parseInt(req.body.year),
-      parseInt(req.body.month)-1,
+      parseInt(req.body.month),
       parseInt(req.body.day),
       parseInt(req.body.hours),
       parseInt(req.body.minutes),

--- a/app_project/jsx_files/DateMenuRow.jsx
+++ b/app_project/jsx_files/DateMenuRow.jsx
@@ -13,10 +13,12 @@ class DateMenuRow extends React.Component {
   }
 
   convert_date(old_date) {
+    // Date is given as UTC string by backend
     let regex = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/g,
         result = regex.exec(old_date);
     if (result) {
       let [year, month, date, hours, minutes] = result.slice(1,6);
+      // Create as UTC from string (with proper month), then convert to timezone
       return new Date(Date.UTC(year, parseInt(month)-1  , date, hours, minutes));
     }
     return null;

--- a/public/javascripts/app_project/DateMenuRow.js
+++ b/public/javascripts/app_project/DateMenuRow.js
@@ -134,6 +134,7 @@ var DateMenuRow = function (_React$Component) {
   _createClass(DateMenuRow, [{
     key: "convert_date",
     value: function convert_date(old_date) {
+      // Date is given as UTC string by backend
       var regex = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/g,
           result = regex.exec(old_date);
       if (result) {
@@ -144,6 +145,8 @@ var DateMenuRow = function (_React$Component) {
             date = _result$slice2[2],
             hours = _result$slice2[3],
             minutes = _result$slice2[4];
+        // Create as UTC from string (with proper month), then convert to timezone
+
 
         return new Date(Date.UTC(year, parseInt(month) - 1, date, hours, minutes));
       }


### PR DESCRIPTION
Fixes the month conversion between the webpage and the backend server. Previously, it was subtracting a month each time. This was property because I created a new React component for the the date & time, and I modified the assessment controller but forgot to modify the project controller.