### PR TITLE
Correct utc timezone difference

### DIFF
--- a/app_project/controller/app_project/assessment_controller.js
+++ b/app_project/controller/app_project/assessment_controller.js
@@ -175,6 +175,7 @@ async function edit_site_assessment(req, res) {
   }
   if (property == "project_start_date" || property == "project_end_date" || 
       property == "assessment_date") {
+    // Can accept the date ISO string (toISOString js method) in date_iso_string
     if (req.body.date_iso_string) {
       d = new Date(req.body.date_iso_string);
     } else {

--- a/app_project/controller/app_project/assessment_controller.js
+++ b/app_project/controller/app_project/assessment_controller.js
@@ -175,13 +175,17 @@ async function edit_site_assessment(req, res) {
   }
   if (property == "project_start_date" || property == "project_end_date" || 
       property == "assessment_date") {
-    var d = new Date(
-      parseInt(req.body.year),
-      parseInt(req.body.month),
-      parseInt(req.body.day),
-      parseInt(req.body.hours),
-      parseInt(req.body.minutes),
-    );
+    if (req.body.date_iso_string) {
+      d = new Date(req.body.date_iso_string);
+    } else {
+      d = new Date(
+        parseInt(req.body.year),
+        parseInt(req.body.month),
+        parseInt(req.body.day),
+        parseInt(req.body.hours),
+        parseInt(req.body.minutes),
+      ); 
+    }
     if (property == "project_start_date") {
       site_assessment.project_start_date = d;
     } else if (property == "project_end_date") {

--- a/app_project/controller/app_project/project_controller.js
+++ b/app_project/controller/app_project/project_controller.js
@@ -192,6 +192,7 @@ async function edit_project(req, res) {
   if (req.body.property == "project_start_date" 
     || req.body.property == "project_end_date") {
     let d;
+    // Can accept the date ISO string (toISOString js method) in date_iso_string
     if (req.body.date_iso_string) {
       d = new Date(req.body.date_iso_string);
     } else {

--- a/app_project/controller/app_project/project_controller.js
+++ b/app_project/controller/app_project/project_controller.js
@@ -63,6 +63,12 @@ async function get_project(req, res) {
                 populate: {path: "materialsItems", model: "MaterialsItem"}})
       .populate("partners").populate("documentPackage").populate("siteAssessment");
   if (project) {
+    if (project.start) {
+      project.start = project.start.toISOString();
+    }
+    if (project.end) {
+      project.end = project.end.toISOString();
+    }
     res.status(200).json(project);
   } else {
     res.status(404).end();
@@ -185,13 +191,18 @@ async function edit_project(req, res) {
   }
   if (req.body.property == "project_start_date" 
     || req.body.property == "project_end_date") {
-    var d = new Date(
-      parseInt(req.body.year),
-      parseInt(req.body.month),
-      parseInt(req.body.day),
-      parseInt(req.body.hours),
-      parseInt(req.body.minutes),
-    );
+    let d;
+    if (req.body.date_iso_string) {
+      d = new Date(req.body.date_iso_string);
+    } else {
+      d = new Date(
+        parseInt(req.body.year),
+        parseInt(req.body.month),
+        parseInt(req.body.day),
+        parseInt(req.body.hours),
+        parseInt(req.body.minutes),
+      ); 
+    }
     if (req.body.property == "project_start_date") {
       project.start = d;
     } else {

--- a/app_project/jsx_files/DateMenuRow.jsx
+++ b/app_project/jsx_files/DateMenuRow.jsx
@@ -1,7 +1,7 @@
 export { DateMenuRow }
 
 // Needs to use Bootstrap datepicker
-// this.props: title, date, change_callback
+// this.props: title, date, change_callback, date_type
 class DateMenuRow extends React.Component {
   constructor(props) {
     super(props);
@@ -17,9 +17,8 @@ class DateMenuRow extends React.Component {
     let regex = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/g,
         result = regex.exec(old_date);
     if (result) {
-      let [year, month, date, hours, minutes] = result.slice(1,6);
-      // Create as UTC from string (with proper month), then convert to timezone
-      return new Date(Date.UTC(year, parseInt(month)-1  , date, hours, minutes));
+      // Create as UTC from string (with proper month)
+      return new Date(old_date);
     }
     return null;
   }
@@ -27,11 +26,7 @@ class DateMenuRow extends React.Component {
   get_data =() => {
     let obj = {
       date_type: this.props.date_type,
-      year: this.state.date.getFullYear(),
-      month: this.state.date.getMonth(),
-      day: this.state.date.getDate(),
-      hours: this.state.date.getHours(),
-      minutes: this.state.date.getMinutes(),
+      date_iso_string: this.state.date.toISOString(),
     };
     return obj;
   };

--- a/app_project/jsx_files/functionHelper.js
+++ b/app_project/jsx_files/functionHelper.js
@@ -6,7 +6,7 @@ const functionHelper = {
         result = regex.exec(old_date);
     if (result) {
       let [year, month, date, hours, minutes] = result.slice(1,6);
-      return new Date(Date.UTC(year, parseInt(month)-1  , date, hours, minutes));
+      return new Date(old_date);
     }
     return null;
   },

--- a/public/javascripts/app_project/DateMenuRow.js
+++ b/public/javascripts/app_project/DateMenuRow.js
@@ -1,5 +1,3 @@
-var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -11,7 +9,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 export { DateMenuRow };
 
 // Needs to use Bootstrap datepicker
-// this.props: title, date, change_callback
+// this.props: title, date, change_callback, date_type
 
 var DateMenuRow = function (_React$Component) {
   _inherits(DateMenuRow, _React$Component);
@@ -24,11 +22,7 @@ var DateMenuRow = function (_React$Component) {
     _this.get_data = function () {
       var obj = {
         date_type: _this.props.date_type,
-        year: _this.state.date.getFullYear(),
-        month: _this.state.date.getMonth(),
-        day: _this.state.date.getDate(),
-        hours: _this.state.date.getHours(),
-        minutes: _this.state.date.getMinutes()
+        date_iso_string: _this.state.date.toISOString()
       };
       return obj;
     };
@@ -138,17 +132,8 @@ var DateMenuRow = function (_React$Component) {
       var regex = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/g,
           result = regex.exec(old_date);
       if (result) {
-        var _result$slice = result.slice(1, 6),
-            _result$slice2 = _slicedToArray(_result$slice, 5),
-            year = _result$slice2[0],
-            month = _result$slice2[1],
-            date = _result$slice2[2],
-            hours = _result$slice2[3],
-            minutes = _result$slice2[4];
-        // Create as UTC from string (with proper month), then convert to timezone
-
-
-        return new Date(Date.UTC(year, parseInt(month) - 1, date, hours, minutes));
+        // Create as UTC from string (with proper month)
+        return new Date(old_date);
       }
       return null;
     }

--- a/public/javascripts/app_project/functionHelper.js
+++ b/public/javascripts/app_project/functionHelper.js
@@ -15,7 +15,7 @@ var functionHelper = {
           hours = _result$slice2[3],
           minutes = _result$slice2[4];
 
-      return new Date(Date.UTC(year, parseInt(month) - 1, date, hours, minutes));
+      return new Date(old_date);
     }
     return null;
   },


### PR DESCRIPTION
Previously, it was manually getting the values for date, month, and year. Now, it uses the ISO date string using toISOString, which already has the timezone in the string so there isn't a need for the conversion for the months (seen in previous PR) and the time.